### PR TITLE
fix: remove BookAuthor and BookTag models from automigrate

### DIFF
--- a/server.go
+++ b/server.go
@@ -84,7 +84,7 @@ func main() {
 		panic(err)
 	}
 
-	db.AutoMigrate(&ServerOption{}, &Service{}, &Book{}, &Author{}, &Tag{}, &ServerOption{}, &BookAuthor{}, &BookTag{})
+	db.AutoMigrate(&ServerOption{}, &Service{}, &Book{}, &Author{}, &Tag{}, &ServerOption{})
 
 	db.First(&serverOption)
 	if serverOption.UUID == "" {


### PR DESCRIPTION
bookauthor and booktag tables are already created by automigrate when passing Book. If not removed, the automiigrate will produce a 'Cannot add a PRIMARY KEY' error when creating a new Database from scratch.